### PR TITLE
Potential fix for code scanning alert no. 28: Database query built from user-controlled sources

### DIFF
--- a/router/warstatus.js
+++ b/router/warstatus.js
@@ -239,7 +239,7 @@ router.get('/warstatus/events', RateLimiter(1, 3), async (req, res) => {
     if (server && !validateServer(server)) {
         return res.status(400).json({ status: 'error', message: 'Invalid server' });
     }
-    const query = server ? { server } : {};
+    const query = server ? { server: { $eq: server } } : {};
     const events = await WarstatusEvents.find(query).sort({ timestamp: -1 }).limit(50);
     res.json({ events });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/CoR-Forum/RegnumStarter-API/security/code-scanning/28](https://github.com/CoR-Forum/RegnumStarter-API/security/code-scanning/28)

To fix the problem, we need to ensure that the `server` parameter is safely embedded into the MongoDB query. We can use the `$eq` operator to ensure that the `server` parameter is interpreted as a literal value and not as a query object. This will prevent any potential injection attacks.

We will modify the query construction on line 242 to use the `$eq` operator for the `server` parameter. This change will ensure that the `server` parameter is treated as a literal value in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
