### PR TITLE
Potential fix for code scanning alert no. 34: Use of externally-controlled format string

### DIFF
--- a/router/warstatus.js
+++ b/router/warstatus.js
@@ -218,7 +218,7 @@ router.get('/warstatus', RateLimiter(1, 3), async (req, res) => {
             res.status(500).json({ status: 'error', message: 'No data available' });
         }
     } catch (error) {
-        console.error(`Error fetching latest war status for server ${server}:`, error);
+        console.error('Error fetching latest war status for server %s:', server, error);
         res.status(500).json({ status: 'error', message: 'Internal server error' });
     }
 });


### PR DESCRIPTION
Potential fix for [https://github.com/CoR-Forum/RegnumStarter-API/security/code-scanning/34](https://github.com/CoR-Forum/RegnumStarter-API/security/code-scanning/34)

To fix the problem, we should ensure that the user-provided `server` value is safely included in the format string. This can be achieved by using the `%s` specifier in the format string and passing the `server` variable as an additional argument to the `console.error` function. This approach ensures that the `server` value is treated as a string and prevents any unintended format specifiers from causing issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
